### PR TITLE
Prepare for Kubernetes Deploy and Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,14 @@ pipeline {
       }
     }
 
+    stage('Dry run deployments') {
+      agent any
+      steps {
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl --context azure apply --dry-run=client --record -f -"
+      }
+    }
+
     stage('Deploy staging to Kubernetes') {
       when { branch 'master' }
       agent any

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,71 @@
+#!groovy
+
+pipeline {
+  agent none
+
+  options {
+    disableConcurrentBuilds()
+  }
+
+  stages {
+    stage('Build Docker image') {
+      agent any
+      steps {
+        script {
+          def dockerRepoName = 'zooniverse/zoomapper'
+          def dockerImageName = "${dockerRepoName}:${GIT_COMMIT}"
+          def newImage = docker.build(dockerImageName)
+
+          if (BRANCH_NAME == 'master') {
+            stage('Update latest tag') {
+              newImage.push()
+              newImage.push('latest')
+            }
+          }
+        }
+      }
+    }
+
+    stage('Deploy staging to Kubernetes') {
+      when { branch 'master' }
+      agent any
+      steps {
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-staging.tmpl | kubectl --context azure apply --record -f -"
+      }
+    }
+
+    stage('Deploy production to Kubernetes') {
+      when { tag 'production-release' }
+      agent any
+      steps {
+        sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl --context azure apply --record -f -"
+      }
+    }
+  }
+
+  post {
+    success {
+      script {
+        if (BRANCH_NAME == 'master' || env.TAG_NAME == 'production-release') {
+          slackSend (
+            color: '#00FF00',
+            message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+            channel: "#ops"
+          )
+        }
+      }
+    }
+
+    failure {
+      script {
+        if (BRANCH_NAME == 'master' || env.TAG_NAME == 'production-release') {
+          slackSend (
+            color: '#FF0000',
+            message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})",
+            channel: "#ops"
+          )
+        }
+      }
+    }
+  }
+}

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,7 +19,7 @@ spec:
           image: zooniverse/zoomapper:__IMAGE_TAG__
           resources:
             requests:
-              memory: "50Mi"
+              memory: "100Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,11 +19,11 @@ spec:
           image: zooniverse/zoomapper:__IMAGE_TAG__
           resources:
             requests:
-              memory: "200Mi"
+              memory: "50Mi"
               cpu: "10m"
             limits:
-              memory: "200Mi"
-              cpu: "500m"
+              memory: "100Mi"
+              cpu: "250m"
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zoomapper-production-app
+  labels:
+    app: zoomapper-production-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zoomapper-production-app
+  template:
+    metadata:
+      labels:
+        app: zoomapper-production-app
+    spec:
+      containers:
+        - name: zoomapper-production-app
+          image: zooniverse/zoomapper:__IMAGE_TAG__
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "10m"
+            limits:
+              memory: "200Mi"
+              cpu: "500m"
+          env:
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
+            - name: RAILS_ENV
+              value: production
+            - name: RAILS_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: zoomapper-production
+                  key: rails-master-key
+          volumeMounts:
+          - mountPath: /tmp
+            name: zoomapper-production-app-data
+      volumes:
+        - name: zoomapper-production-app-data
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/zoomapper-production-app-data
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zoomapper-production-app
+spec:
+  selector:
+    app: zoomapper-production-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -24,25 +24,6 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "500m"
-          env:
-            - name: RAILS_LOG_TO_STDOUT
-              value: "true"
-            - name: RAILS_ENV
-              value: production
-            - name: RAILS_MASTER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: zoomapper-production
-                  key: rails-master-key
-          volumeMounts:
-          - mountPath: /tmp
-            name: zoomapper-production-app-data
-      volumes:
-        - name: zoomapper-production-app-data
-          hostPath:
-            # directory location on host node temp disk
-            path: /mnt/zoomapper-production-app-data
-            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -19,7 +19,7 @@ spec:
           image: zooniverse/zoomapper:__IMAGE_TAG__
           resources:
             requests:
-              memory: "50Mi"
+              memory: "100Mi"
               cpu: "10m"
             limits:
               memory: "100Mi"

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -24,25 +24,6 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "500m"
-          env:
-            - name: RAILS_LOG_TO_STDOUT
-              value: "true"
-            - name: RAILS_ENV
-              value: staging
-            - name: RAILS_MASTER_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: zoomapper-staging
-                  key: rails-master-key
-          volumeMounts:
-          - mountPath: /tmp
-            name: zoomapper-staging-app-data
-      volumes:
-        - name: zoomapper-staging-app-data
-          hostPath:
-            # directory location on host node temp disk
-            path: /mnt/zoomapper-staging-app-data
-            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zoomapper-staging-app
+  labels:
+    app: zoomapper-staging-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zoomapper-staging-app
+  template:
+    metadata:
+      labels:
+        app: zoomapper-staging-app
+    spec:
+      containers:
+        - name: zoomapper-staging-app
+          image: zooniverse/zoomapper:__IMAGE_TAG__
+          resources:
+            requests:
+              memory: "200Mi"
+              cpu: "10m"
+            limits:
+              memory: "200Mi"
+              cpu: "500m"
+          env:
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
+            - name: RAILS_ENV
+              value: staging
+            - name: RAILS_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: zoomapper-staging
+                  key: rails-master-key
+          volumeMounts:
+          - mountPath: /tmp
+            name: zoomapper-staging-app-data
+      volumes:
+        - name: zoomapper-staging-app-data
+          hostPath:
+            # directory location on host node temp disk
+            path: /mnt/zoomapper-staging-app-data
+            type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zoomapper-staging-app
+spec:
+  selector:
+    app: zoomapper-staging-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: NodePort

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -19,11 +19,11 @@ spec:
           image: zooniverse/zoomapper:__IMAGE_TAG__
           resources:
             requests:
-              memory: "200Mi"
+              memory: "50Mi"
               cpu: "10m"
             limits:
-              memory: "200Mi"
-              cpu: "500m"
+              memory: "100Mi"
+              cpu: "250m"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This PR creates a Jenkinsfile and a couple Kubernetes deployment configs to prepare the Zoomapper repo for auto deployment. **Note:** this merges into the already open `add-docker` branch. The files created here are based on the same files from [TOVE](https://github.com/zooniverse/tove) with the image names changed to be `zoomapper`. It could be that some of these files need to changed based on the use case of this repo. 