### PR TITLE
Add Ingress to Kubernetes deployment files

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -1,3 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: zoomapper-production-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: zoomapper-production-tls
+  dnsNames:
+    - zoomapper.zooniverse.org
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -37,3 +37,36 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: zoomapper-production-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - panoptes.azure.zooniverse.org
+    - panoptes.zooniverse.org
+    secretName: zoomapper-production-tls-secret
+  rules:
+  - host: panoptes.azure.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: zoomapper-production-app
+          servicePort: 80
+        path: /(.*)
+  - host: panoptes.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: zoomapper-production-app
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -42,18 +42,17 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: zoomapper-production-ingress
+  name: zoomapper.zooniverse.org
   annotations:
     kubernetes.io/ingress.class: nginx
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
   tls:
   - hosts:
     - zoomapper.zooniverse.org
-    secretName: zoomapper-production-tls-secret
+    secretName: zoomapper-production-tls
   rules:
   - host: zoomapper.zooniverse.org
     http:
@@ -61,4 +60,4 @@ spec:
       - backend:
           serviceName: zoomapper-production-app
           servicePort: 80
-        path: /(.*)
+        path: /

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -52,18 +52,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - panoptes.azure.zooniverse.org
-    - panoptes.zooniverse.org
+    - zoomapper.zooniverse.org
     secretName: zoomapper-production-tls-secret
   rules:
-  - host: panoptes.azure.zooniverse.org
-    http:
-      paths:
-      - backend:
-          serviceName: zoomapper-production-app
-          servicePort: 80
-        path: /(.*)
-  - host: panoptes.zooniverse.org
+  - host: zoomapper.zooniverse.org
     http:
       paths:
       - backend:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -37,3 +37,36 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: zoomapper-staging-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
+spec:
+  tls:
+  - hosts:
+    - panoptes.azure.zooniverse.org
+    - panoptes.zooniverse.org
+    secretName: zoomapper-staging-tls-secret
+  rules:
+  - host: panoptes.azure.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: zoomapper-staging-app
+          servicePort: 80
+        path: /(.*)
+  - host: panoptes.zooniverse.org
+    http:
+      paths:
+      - backend:
+          serviceName: zoomapper-staging-app
+          servicePort: 80
+        path: /(.*)

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -1,3 +1,17 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: zoomapper-staging-tls
+  labels:
+    use-azuredns-solver: "true"
+spec:
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  secretName: zoomapper-staging-tls
+  dnsNames:
+    - zoomapper-staging.zooniverse.org
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -52,18 +52,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - panoptes.azure.zooniverse.org
-    - panoptes.zooniverse.org
+    - zoomapper-staging.zooniverse.org
     secretName: zoomapper-staging-tls-secret
   rules:
-  - host: panoptes.azure.zooniverse.org
-    http:
-      paths:
-      - backend:
-          serviceName: zoomapper-staging-app
-          servicePort: 80
-        path: /(.*)
-  - host: panoptes.zooniverse.org
+  - host: zoomapper-staging.zooniverse.org
     http:
       paths:
       - backend:

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -42,18 +42,17 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: zoomapper-staging-ingress
+  name: zoomapper-staging.zooniverse.org
   annotations:
     kubernetes.io/ingress.class: nginx
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
 spec:
   tls:
   - hosts:
     - zoomapper-staging.zooniverse.org
-    secretName: zoomapper-staging-tls-secret
+    secretName: zoomapper-staging-tls
   rules:
   - host: zoomapper-staging.zooniverse.org
     http:
@@ -61,4 +60,4 @@ spec:
       - backend:
           serviceName: zoomapper-staging-app
           servicePort: 80
-        path: /(.*)
+        path: /


### PR DESCRIPTION
This PR adds an Ingress to each of the Kubernetes deployment files (deployment and staging). Changes here are based off of our setup in the [Panoptes deployment files](https://github.com/zooniverse/panoptes/blob/e15fa049c7fa88777b6da1275c6964284c376ed9/kubernetes/deployment-production.tmpl#L478-L516).

Not sure much more is needed here. I did remove the [sign in](https://github.com/zooniverse/panoptes/blob/e15fa049c7fa88777b6da1275c6964284c376ed9/kubernetes/deployment-production.tmpl#L493) host from this setup, as mapping viz tools does not have any sort of auth associated with it.