### PR TITLE
Don't place restrictions on rendered domains

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,10 +3,7 @@
     "paths": {
       "root": "",
       "mbtiles": "mbtiles"
-    },
-    "domains": [
-      "localhost:8080"
-    ]
+    }
   },
   "data": {
     "falklands": {


### PR DESCRIPTION
Previously, the config file here would only allow tiles to render at `localhost:8080`. However, the `domain` key is optional, per the [docs](https://tileserver.readthedocs.io/en/latest/config.html#domains).

I tested this out by changing the config domain to `localhost: 8070`, then accessed the tiles locally at `localhost:8080`. In doing so, I'm seeing the same error on the deployed app: `Error at Actor.receive`. Removing the optional `domain` key takes care of this.