### PR TITLE
Remove ingress definition

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -51,30 +51,3 @@ spec:
       port: 80
       targetPort: 80
   type: NodePort
-
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: zoomapper.azure.zooniverse.org
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-    nginx.ingress.kubernetes.io/set-real-ip-from: "10.0.0.0/8"
-spec:
-  tls:
-  - hosts:
-    - zoomapper.azure.zooniverse.org
-    secretName: zoomapper-production-tls
-  rules:
-  - host: zoomapper.azure.zooniverse.org
-    http:
-      paths:
-      - pathType: Prefix
-        path: /
-        backend:
-          service:
-            name: zoomapper-production-app
-            port:
-              number: 80


### PR DESCRIPTION
zoomapper.zooniverse.org is throwing 502s after this last deploy, while zoomapper.azure.zooniverse.org is working correctly but is failing the TLS check. So the ingress for this app is moving to the static repo in the zooniverse.org ingress as a whole, where hopefully it behaves like all the other apps set up in this manner.